### PR TITLE
Update to NotificationNode.js and main.js to avoid using synchronous xhr

### DIFF
--- a/NotificationNode.js
+++ b/NotificationNode.js
@@ -1,10 +1,10 @@
-define([ "dojo/text", "dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dojo/dom-construct", "dGrowl/NotificationNode", "dojo/dom-class", "dojo/_base/event", "dojo/_base/lang"],
-	   function(t, declare, base, templated, domCon, NotificationNode, domClass, event, lang)
+define([ "dojo/text", "dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dojo/dom-construct", "dGrowl/NotificationNode", "dojo/dom-class", "dojo/_base/event", "dojo/_base/lang", "dojo/text!./NotificationNode.html"],
+	   function(t, declare, base, templated, domCon, NotificationNode, domClass, event, lang, templateString)
 {
 	return declare('dGrowl',
 	[base, templated],
 	{
-		'templateString':dojo.cache('dGrowl', 'NotificationNode.html'),
+		'templateString':templateString,
 		'title':'',
 		'message':'',
 		'duration':5000,

--- a/main.js
+++ b/main.js
@@ -1,10 +1,10 @@
-define([ "dojo/text", "dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dojo/topic", "dojo/dom-construct", "dGrowl/NotificationNode", "dojo/query", "dojo/_base/lang", "dojo/dom-class"],
-	   function(t, declare, base, templated, topic, domCon, NotificationNode, query, lang, domClass)
+define([ "dojo/text", "dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dojo/topic", "dojo/dom-construct", "dGrowl/NotificationNode", "dojo/query", "dojo/_base/lang", "dojo/dom-class", "dojo/text!./main.html"],
+	   function(t, declare, base, templated, topic, domCon, NotificationNode, query, lang, domClass, templateString)
 {
 	return declare('dGrowl',
 	[base, templated],
 	{
-		'templateString':dojo.cache('dGrowl', 'main.html'),
+		'templateString':templateString,
 		'channels':[{name:'default', pos:0}], // channel user definitions
 		'orientation':'topRight',
 		'defaultChannel':null,


### PR DESCRIPTION
Using an up-to-date dojo way of getting a template string, thus avoiding a synchronous xhr request.